### PR TITLE
Close file even if exception is raised somewhere in _dict_to_h5

### DIFF
--- a/test_wrapper.py
+++ b/test_wrapper.py
@@ -275,3 +275,13 @@ def test_load_lazy_nested():
     assert(res['a'] is None)
     assert(res['test1']['b'] is None)
     assert(res['test2']['test3']['c'] is None)
+
+
+def test_file_close_on_exception():
+    res = {'a': 5}
+    h5w.save(fn, res, write_mode='w')
+    try:
+        h5w.save(fn, res, write_mode='a', overwrite_dataset=False)
+    except KeyError:
+        pass
+    h5w.save(fn, res, write_mode='w')

--- a/wrapper.py
+++ b/wrapper.py
@@ -100,17 +100,19 @@ def save(filename, d, write_mode='a', overwrite_dataset=False,
                       "accessability: Unable to open "
                       "file)".format(filename=filename))
     else:
-        if dict_label:
-            base = f.require_group(dict_label)
-            _dict_to_h5(f, d, overwrite_dataset, parent_group=base,
-                        compression=compression)
-        else:
-            _dict_to_h5(f, d, overwrite_dataset, compression=compression)
-        fname = f.filename
-        f.close()
-        if overwrite_dataset is True and resize is True:
-            call(['h5repack', '-i', fname, '-o', fname + '_repack'])
-            call(['mv', fname + '_repack', fname])
+        try:
+            if dict_label:
+                base = f.require_group(dict_label)
+                _dict_to_h5(f, d, overwrite_dataset, parent_group=base,
+                            compression=compression)
+            else:
+                _dict_to_h5(f, d, overwrite_dataset, compression=compression)
+        finally:  # make sure file is closed even if an exception is raised
+            fname = f.filename
+            f.close()
+            if overwrite_dataset is True and resize is True:
+                call(['h5repack', '-i', fname, '-o', fname + '_repack'])
+                call(['mv', fname + '_repack', fname])
 
 
 def load(filename, path='', lazy=False):


### PR DESCRIPTION
Currently a file might be corrupted if an exception is raised while storing data. This PR fixes the issue by introducing a `final` clause in `add_to_h5` that makes sure that the file is properly closed.