### PR TITLE
Enhancement/better api

### DIFF
--- a/test_wrapper.py
+++ b/test_wrapper.py
@@ -62,29 +62,29 @@ class WrapperTest(unittest.TestCase):
 
     def test_write_and_load_with_label(self):
         res = self.construct_simpledata()
-        h5w.add_to_h5(fn, res, write_mode='w', dict_label='test_label')
+        h5w.save(fn, res, write_mode='w', dict_label='test_label')
         for key, val in zip(simpledata_str, simpledata_val):
-            self.assertEqual(h5w.load_h5(fn, 'test_label/' + key), val)
+            self.assertEqual(h5w.load(fn, 'test_label/' + key), val)
 
     def test_store_and_load_dataset_directly(self):
         res = self.construct_simpledata()
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         for key, val in zip(simpledata_str, simpledata_val):
-            self.assertEqual(h5w.load_h5(fn, '/' + key), val)
+            self.assertEqual(h5w.load(fn, '/' + key), val)
 
     def test_old_store_and_load_simpledata(self):
         res = self.construct_simpledata()
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         res.clear()
-        res = h5w.load_h5(fn)
+        res = h5w.load(fn)
         for key, val in zip(simpledata_str, simpledata_val):
             self.assertEqual(res[key], val)
 
     def test_store_and_load_simpledata(self):
         res = self.construct_simpledata()
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         res.clear()
-        res = h5w.load_h5(fn)
+        res = h5w.load(fn)
         for key, val in zip(simpledata_str, simpledata_val):
             self.assertEqual(res[key], val)
 
@@ -92,9 +92,9 @@ class WrapperTest(unittest.TestCase):
         res = {}
         for key, val in zip(arraydata_str, arraydata_val):
             res[key] = val
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         res.clear()
-        res = h5w.load_h5(fn)
+        res = h5w.load(fn)
         for key, val in zip(arraydata_str, arraydata_val):
             assert_array_equal(res[key], val)
 
@@ -102,9 +102,9 @@ class WrapperTest(unittest.TestCase):
         res = {}
         for key, val in zip(listdata_str, listdata_val):
             res[key] = val
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         res.clear()
-        res = h5w.load_h5(fn)
+        res = h5w.load(fn)
         for key, val in zip(listdata_str, listdata_val):
             assert_array_equal(res[key], val)
 
@@ -112,9 +112,9 @@ class WrapperTest(unittest.TestCase):
         res = {}
         for key, val in zip(tupledata_str, tupledata_val):
             res[key] = val
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         res.clear()
-        res = h5w.load_h5(fn)
+        res = h5w.load(fn)
         for key, val in zip(tupledata_str, tupledata_val):
             assert_array_equal(res[key], np.array(val))
 
@@ -122,44 +122,44 @@ class WrapperTest(unittest.TestCase):
         res = {}
         for key, val in zip(dictdata_str, dictdata_val):
             res[key] = val
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         res.clear()
-        res = h5w.load_h5(fn)
+        res = h5w.load(fn)
         for dkey, dval in zip(dictdata_str, dictdata_val):
             for key, val in dval.items():
                 self.assertEqual(res[dkey][key], val)
 
     def test_overwrite_dataset(self):
         res = {'a': 5}
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         res.clear()
         res = {'a': 6}
-        self.assertRaises(KeyError, h5w.add_to_h5,
+        self.assertRaises(KeyError, h5w.save,
                           fn, res, write_mode='a', overwrite_dataset=False)
         res.clear()
-        res = h5w.load_h5(fn)
+        res = h5w.load(fn)
         self.assertEqual(res['a'], 5)  # dataset should still contain old value
         res.clear()
         res = {'a': 6}
-        h5w.add_to_h5(
+        h5w.save(
             fn, res, write_mode='a', overwrite_dataset=True)
         res.clear()
-        res = h5w.load_h5(fn)
+        res = h5w.load(fn)
         self.assertEqual(res['a'], 6)  # dataset should contain new value
 
     def test_write_empty_array(self):
         res = {'a': [], 'b': np.array([])}
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         res.clear()
-        res = h5w.load_h5(fn)
+        res = h5w.load(fn)
         assert_array_equal(res['a'], [])
         assert_array_equal(res['b'], [])
 
     def test_write_nested_empty_array(self):
         res = {'a': [[], []], 'b': np.array([[], []])}
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         res.clear()
-        res = h5w.load_h5(fn)
+        res = h5w.load(fn)
         assert_array_equal(res['a'], [[], []])
         self.assertEqual(np.shape(res['a']), (2, 0))
         assert_array_equal(res['b'], [[], []])
@@ -167,49 +167,49 @@ class WrapperTest(unittest.TestCase):
 
     def test_read_empty_array_via_path(self):
         res = {'a': np.array([[], []])}
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         res.clear()
-        res = h5w.load_h5(fn, path='a')
+        res = h5w.load(fn, path='a')
         assert_array_equal(res, [[], []])
         self.assertEqual(np.shape(res), (2, 0))
 
     def test_handle_nonexisting_path(self):
         res = {}
         stest = 'this is a test'
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         try:
-            res = h5w.load_h5(fn, path='test/')
+            res = h5w.load(fn, path='test/')
             raise Exception()  # should not get until here
         except KeyError:
             res['test'] = stest
-            h5w.add_to_h5(fn, res)
+            h5w.save(fn, res)
             res.clear()
-            res = h5w.load_h5(fn, path='test/')
+            res = h5w.load(fn, path='test/')
             self.assertEqual(res, stest)
 
     def test_store_none(self):
         res = {'a1': None}
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         res.clear()
-        res = h5w.load_h5(fn)
+        res = h5w.load(fn)
         self.assertIsNone(res['a1'])
 
     def test_handle_nonexisting_file(self):
         try:
-            h5w.load_h5('asdasd.h5')
+            h5w.load('asdasd.h5')
             raise Exception()  # should not get until here
         except IOError:
             pass
 
     def test_store_and_load_custom_array(self):
         a = [[1, 2, 3, 4], [6, 7]]
-        h5w.add_to_h5(fn, {'a': a}, overwrite_dataset=True)
+        h5w.save(fn, {'a': a}, overwrite_dataset=True)
         # loading the whole data
-        res = h5w.load_h5(fn)
+        res = h5w.load(fn)
         for i in xrange(len(a)):
             self.assertLess(np.sum(a[i] - res['a'][i]), 1e-12)
         # loading path directly
-        res = h5w.load_h5(fn, path='a/')
+        res = h5w.load(fn, path='a/')
         for i in xrange(len(a)):
             self.assertLess(np.sum(a[i] - res[i]), 1e-12)
 
@@ -217,22 +217,22 @@ class WrapperTest(unittest.TestCase):
     def test_store_and_load_quantities_array(self):
         data = {'times': np.array([1, 2, 3]) * pq.ms, 'positions':
                 np.array([1, 2, 3]) * pq.cm}
-        h5w.add_to_h5(fn, data, overwrite_dataset=True)
+        h5w.save(fn, data, overwrite_dataset=True)
         # loading the whole data
-        res = h5w.load_h5(fn)
+        res = h5w.load(fn)
         self.assertEqual(res['times'].dimensionality,
                          data['times'].dimensionality)
 
     def test_store_and_load_with_compression(self):
         data = {'a': 1, 'test1': {'b': 2}, 'test2': {
             'test3': {'c': np.array([1, 2, 3])}}}
-        h5w.add_to_h5(fn, data, write_mode='w', compression='gzip')
-        h5w.load_h5(fn)
+        h5w.save(fn, data, write_mode='w', compression='gzip')
+        h5w.load(fn)
 
     def test_store_and_test_key_types(self):
         data = {'a': 1, (1, 2): {4: 2.}, 4.: 3.}
-        h5w.add_to_h5(fn, data, write_mode='w')
-        res = h5w.load_h5(fn)
+        h5w.save(fn, data, write_mode='w')
+        res = h5w.load(fn)
 
         keys = ['a', (1, 2), 4.]
         for k in keys:
@@ -241,18 +241,18 @@ class WrapperTest(unittest.TestCase):
 
     def test_load_lazy_simple(self):
         res = self.construct_simpledata()
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         res.clear()
-        res = h5w.load_h5(fn, lazy=True)
+        res = h5w.load(fn, lazy=True)
         for key, obj in res.items():
             self.assertIsNone(obj)
 
     def test_load_lazy_nested(self):
         res = {'a': 1, 'test1': {'b': 2}, 'test2': {
             'test3': {'c': np.array([1, 2, 3])}}}
-        h5w.add_to_h5(fn, res, write_mode='w')
+        h5w.save(fn, res, write_mode='w')
         res.clear()
-        res = h5w.load_h5(fn, lazy=True)
+        res = h5w.load(fn, lazy=True)
         self.assertIsNone(res['a'])
         self.assertIsNone(res['test1']['b'])
         self.assertIsNone(res['test2']['test3']['c'])

--- a/wrapper.py
+++ b/wrapper.py
@@ -34,7 +34,7 @@ from subprocess import call
 import warnings
 
 # deprecation warnings are printed to sys.stdout
-warnings.simplefilter('always', category=DeprecationWarning)
+warnings.simplefilter('default', category=DeprecationWarning)
 
 # check whether quantities is available
 try:

--- a/wrapper.py
+++ b/wrapper.py
@@ -19,8 +19,8 @@ loading the file.
 Functions
 ---------
 
-add_to_h5 : store nested dictionary in hdf5 file
-load_h5 : load nested dictionary from hdf5 file
+save : store nested dictionary in hdf5 file
+load : load nested dictionary from hdf5 file
 
 """
 
@@ -30,11 +30,15 @@ import numpy as np
 import collections
 from subprocess import call
 import ast
+import warnings
 
 import h5py
 if int(re.sub('\.', '', h5py.version.version)) < 230:
     raise ImportError("Using h5py version {version}. Version must "
                       "be >= 2.3.0".format(version=h5py.version.version))
+
+# deprecation warnings are printed to sys.stdout
+warnings.simplefilter('always', category=DeprecationWarning)
 
 # check whether quantities is available
 try:
@@ -44,7 +48,7 @@ except ImportError:
     quantities_found = False
 
 
-def add_to_h5(filename, d, write_mode='a', overwrite_dataset=False,
+def save(filename, d, write_mode='a', overwrite_dataset=False,
               resize=False, dict_label='', compression=None):
     """
     Save a dictionary to an hdf5 file.
@@ -85,7 +89,7 @@ def add_to_h5(filename, d, write_mode='a', overwrite_dataset=False,
     >>> d = {}
     >>> d['a'] = {'a1': [1, 2, 3], 'a2': 4., 'a3': {'a31': 'Test'}}
     >>> d['b'] = 'string'
-    >>> h5w.add_to_h5('example.h5', d)
+    >>> h5w.save('example.h5', d)
     """
     try:
         f = h5py.File(filename, write_mode)
@@ -107,7 +111,7 @@ def add_to_h5(filename, d, write_mode='a', overwrite_dataset=False,
             call(['mv', fname + '_repack', fname])
 
 
-def load_h5(filename, path='', lazy=False):
+def load(filename, path='', lazy=False):
     """
     Loads a dictionary from an hdf5 file.
 
@@ -131,8 +135,8 @@ def load_h5(filename, path='', lazy=False):
     >>> d = {}
     >>> d['a'] = {'a1': [1, 2, 3], 'a2': 4., 'a3': {'a31': 'Test'}}
     >>> d['b'] = 'string'
-    >>> h5w.add_to_h5('example.h5', d)
-    >>> h5w.load_h5('example.h5')
+    >>> h5w.save('example.h5', d)
+    >>> h5w.load('example.h5')
     {u'a': {u'a1': array([1, 2, 3]), u'a2': 4.0, u'a3': {u'a31': 'Test'}},
     u'b': 'string'}
 
@@ -297,3 +301,18 @@ def _load_custom_shape(f):
         data_reshaped.append(np.array(f.value[counter:counter + l]))
         counter += l
     return np.array(data_reshaped, dtype=object)
+
+
+# Deprecated names for load and save routine
+def add_to_h5(filename, d, write_mode='a', overwrite_dataset=False,
+              resize=False, dict_label='', compression=None):
+    warnings.warn("Deprecated function name. This function "
+                  "will be removed in the next release. Please use save() instead.", DeprecationWarning)
+    save(filename, d, write_mode=write_mode, overwrite_dataset=overwrite_dataset,
+         resize=resize, dict_label=dict_label, compression=compression)
+    
+
+def load_h5(filename, path='', lazy=False):
+    warnings.warn("Deprecated function name. This function "
+                  "will be removed in the next release. Please use load() instead.", DeprecationWarning)
+    return load(filename, path=path, lazy=lazy)

--- a/wrapper.py
+++ b/wrapper.py
@@ -49,7 +49,7 @@ except ImportError:
 
 
 def save(filename, d, write_mode='a', overwrite_dataset=False,
-              resize=False, dict_label='', compression=None):
+         resize=False, dict_label='', compression=None):
     """
     Save a dictionary to an hdf5 file.
 
@@ -316,12 +316,14 @@ def _load_custom_shape(f):
 def add_to_h5(filename, d, write_mode='a', overwrite_dataset=False,
               resize=False, dict_label='', compression=None):
     warnings.warn("Deprecated function name. This function "
-                  "will be removed in the next release. Please use save() instead.", DeprecationWarning)
+                  "will be removed in the next release. Please use save() instead.",
+                  DeprecationWarning)
     save(filename, d, write_mode=write_mode, overwrite_dataset=overwrite_dataset,
          resize=resize, dict_label=dict_label, compression=compression)
-    
+
 
 def load_h5(filename, path='', lazy=False):
     warnings.warn("Deprecated function name. This function "
-                  "will be removed in the next release. Please use load() instead.", DeprecationWarning)
+                  "will be removed in the next release. Please use load() instead.",
+                  DeprecationWarning)
     return load(filename, path=path, lazy=lazy)


### PR DESCRIPTION
This PR introduces new names for the API functions, i.e. replaces `add_to_h5` by `save` and `load_h5` by `load`.

To ensure backwards compatibility for some time, I added functions with the old names that forward to the new functions and issue a deprecation warnings when being used.

Fixes #25 .