### PR TITLE
Improve performance of _load_custom_shape function

### DIFF
--- a/wrapper.py
+++ b/wrapper.py
@@ -309,11 +309,9 @@ def _load_custom_shape(f):
     Reshape array with unequal dimensions into original shape.
     """
     data_reshaped = []
-    counter = 0
     value = f.value
-    for l in f.attrs['oldshape']:
+    for counter, l in _accumulate(f.attrs['oldshape']):
         data_reshaped.append(np.array(value[counter:counter + l]))
-        counter += l
     return np.array(data_reshaped, dtype=object)
 
 
@@ -332,3 +330,15 @@ def load_h5(filename, path='', lazy=False):
                   "will be removed in the next release. Please use load() instead.",
                   DeprecationWarning)
     return load(filename, path=path, lazy=lazy)
+
+
+# Helper function
+def _accumulate(iterator):
+    """
+    Create a generator to iterate over the accumulated
+    values of the given iterator.
+    """
+    total = 0
+    for item in iterator:
+        yield total, item
+        total += item

--- a/wrapper.py
+++ b/wrapper.py
@@ -310,8 +310,9 @@ def _load_custom_shape(f):
     """
     data_reshaped = []
     counter = 0
+    value = f.value
     for l in f.attrs['oldshape']:
-        data_reshaped.append(np.array(f.value[counter:counter + l]))
+        data_reshaped.append(np.array(value[counter:counter + l]))
         counter += l
     return np.array(data_reshaped, dtype=object)
 


### PR DESCRIPTION
This PR leads to a significant improvement of the `_load_custom_shape` function.
It addresses #34 .
I measured the performance of the current master vs. the 0.0.1-release for loading a 20 MB data file containing arrays with custom shapes. The result was

|||
|---------|--------|
| 0.0.1 | 0.06 s |
| master | 2.06 s |
| enhancement/custom_shape_performance | 0.05 s |

Using python's line_profiler, I found that retrieving the value of an hdf5 group is quite costly. In the current master, this retrieval is inside the loop in which the loaded array is shaped to the required shape. Simply moving this out of the loop leads to a huge reduction of runtime.

**master**
```
Function: _load_custom_shape at line 306

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   306                                           @profile
   307                                           def _load_custom_shape(f):
   308                                               """
   309                                               Reshape array with unequal dimensions into original shape.
   310                                               """
   311         2            2      1.0      0.0      data_reshaped = []
   312         2            0      0.0      0.0      counter = 0
   313      1002         1610      1.6      0.1      for l in f.attrs['oldshape']:
   314      1000      2095013   2095.0     99.8          data_reshaped.append(np.array(f.value[counter:counter + l]))
   315      1000         1803      1.8      0.1          counter += l
   316         2           41     20.5      0.0      return np.array(data_reshaped, dtype=object)

Total time: 2.15489 s
```

**enhancement/custom_shape_performance**
```
Function: _load_custom_shape at line 306

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   306                                           @profile
   307                                           def _load_custom_shape(f):
   308                                               """
   309                                               Reshape array with unequal dimensions into original shape.
   310                                               """
   311         2            3      1.5      0.0      data_reshaped = []
   312         2            2      1.0      0.0      counter = 0
   313         2         4065   2032.5     28.0      value = f.value
   314      1002          598      0.6      4.1      for l in f.attrs['oldshape']:
   315      1000         9298      9.3     64.0          data_reshaped.append(np.array(value[counter:counter + l]))
   316      1000          520      0.5      3.6          counter += l
   317         2           51     25.5      0.4      return np.array(data_reshaped, dtype=object)
Total time: 0.072391 s
```


