### PR TITLE
Change minimal h5py version to 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - conda update --yes conda
   - pip install --upgrade pip
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy h5py
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy h5py==2.3.1
   - pip install --upgrade quantities pytest
   - pip install docopt
 script:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # h5py_wrapper [![Py version](https://img.shields.io/badge/python-2.6%2C%202.7-blue.svg)](www.python.org)
 A wrapper to conveniently store nested python dictionaries in hdf5 files. It exposes two basic functions to the user `wrapper.add_to_h5` and `wrapper.load_h5`.
 
-Requires h5py version 2.3.0 or higher. [![PyPI version](https://badge.fury.io/py/h5py.svg)](https://badge.fury.io/py/h5py)
+Requires h5py version 2.3.1 or higher. [![PyPI version](https://badge.fury.io/py/h5py.svg)](https://badge.fury.io/py/h5py)
 
 Code status
 ===========


### PR DESCRIPTION
This PR changes the required minimal version of h5py to 2.3.1, because 2.3.0 seems to be broken and cannot be installed.