### PR TITLE
Add boolean so supported data types

### DIFF
--- a/convert_h5file.py
+++ b/convert_h5file.py
@@ -36,6 +36,8 @@ def _dict_check_for_numpy_types(d):
             d[key] = int(value)
         elif isinstance(value, (np.float)):
             d[key] = float(value)
+        elif isinstance(value, (np.bool_)):
+            d[key] = bool(value)
 
 
 def _get_previous_version(version):

--- a/test_wrapper.py
+++ b/test_wrapper.py
@@ -25,6 +25,7 @@ fn2 = 'data2.h5'
 i0 = 6
 f0 = 3.14159
 s0 = 'this is a test'
+b0 = True
 
 l0i = [1, 2, 3, 4, 5]
 l0s = ['a', 'b', 'c']
@@ -40,8 +41,8 @@ d0 = {'i': i0, 'f': f0, 's': s0}
 dn0 = {'d1': d0, 'd2': d0}
 
 # define containers
-simpledata_str = ['i', 'f', 's']
-simpledata_val = [i0, f0, s0]
+simpledata_str = ['i', 'f', 's', 'b']
+simpledata_val = [i0, f0, s0, b0]
 
 arraydata_str = ['ai', 'as', 'm']
 arraydata_val = [np.array(l0i), np.array(l0s), np.array(ll0)]

--- a/wrapper.py
+++ b/wrapper.py
@@ -360,6 +360,7 @@ valuetype_dict = {'tuple': 'tuple',
                   'float': 'float',
                   'int': 'int',
                   'str': 'str',
+                  'bool': 'bool',
                   'Quantity': 'pq.Quantity'}
 
 


### PR DESCRIPTION
This PR fixes the bug that the wrapper does not support boolean data anymore. This was erroneously introduced by #32 .