### PR TITLE
Travis: Change python 3 version from 3.4 to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - source activate myenv
   - pip install --upgrade pip
 install:
-  - conda install --yes numpy h5py==2.3.1
+  - conda install --yes numpy h5py==2.7.0
   - pip install --upgrade quantities future requests
   - pip install pytest pytest-cov coveralls
   - pip install --upgrade docopt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.4"
+  - "3.6"
 branches:
   only:
     - master


### PR DESCRIPTION
This pull request is supposed to fix #63 and updates the python 3 version that Travis tests for to 3.6.
Conda reports a conflict if the h5py version is set to 2.3.1, so I simply changed this to 2.7.0 which is the most recent version and works fine.