### PR TITLE
Properly catch KeyError of deprecated file when loading a specific path

### DIFF
--- a/h5py_wrapper/wrapper.py
+++ b/h5py_wrapper/wrapper.py
@@ -144,14 +144,15 @@ def load(filename, path='', lazy=False):
     else:
         try:
             if not path:
-                _, d = _dict_from_h5(f, lazy=lazy)
+                obj = f
             else:
                 try:
-                    _, d = _dict_from_h5(f[path], lazy=lazy)
+                    obj = f[path]
                 except KeyError:
                     raise KeyError("unable to open {filename}/{path} "
                                    "(Key accessability: Unable to access "
                                    "key)".format(filename=filename, path=path))
+            _, d = _dict_from_h5(obj, lazy=lazy)
         finally:
             f.close()
     return d


### PR DESCRIPTION
This PR fixes #55 .

