### PR TITLE
Bug/conversion 101

### DIFF
--- a/convert_h5file
+++ b/convert_h5file
@@ -19,6 +19,7 @@ import docopt
 import os
 import importlib
 import sys
+import tempfile
 
 import h5py_wrapper.wrapper as h5w
 import h5py_wrapper.lib as h5w_lib
@@ -28,11 +29,16 @@ if __name__ == '__main__':
     # First get release version used to create the file to be converted
     version_stripped = args['--release'].replace('.', '')
     release_base_name = '_'.join(('h5py_wrapper', version_stripped))
+    # This case distinction is necessary because the directory structure
+    # changes between versions
+    module = '.'.join((release_base_name, 'wrapper'))
     try:
-        h5w_old = importlib.import_module('.'.join((release_base_name, 'wrapper')))
+        h5w_old = importlib.import_module(module)
     except ImportError:
-        h5w_lib.get_previous_version(args['--release'])
-        h5w_old = importlib.import_module('.'.join((release_base_name, 'wrapper')))
+        tmpdir = tempfile.mkdtemp()
+        h5w_lib.get_previous_version(args['--release'], tmpdir)
+        sys.path.append(tmpdir)
+        h5w_old = importlib.import_module(module)
 
     files = args['<files>'] or sys.stdin.read().splitlines()
     for fn in files:

--- a/h5py_wrapper/lib.py
+++ b/h5py_wrapper/lib.py
@@ -35,6 +35,10 @@ def get_previous_version(version, path):
             f.write(r.content)
         with tarfile.open(fn) as f:
             f.extractall(path=path)
+        # This is necessary to account for the fact that version 0.0.1 was called v0.0.1
+        # but all subsequent version are called X.X.X without the leading v.
+        if version[0] == 'v':
+            version = version[1:]
         os.rename(os.path.join(path, '-'.join(('h5py_wrapper', version))),
                   os.path.join(path, '_'.join(('h5py_wrapper', version.replace('.', '')))))
     except requests.exceptions.HTTPError:

--- a/h5py_wrapper/lib.py
+++ b/h5py_wrapper/lib.py
@@ -15,6 +15,14 @@ def get_previous_version(version, path):
     Retrieves the given version of the wrapper from github as a tar
     archive and extracts its contents to the current directory.
 
+    Parameters
+    ----------
+    version : str
+        Version number in format 'X.X.X'
+        Note that for version 0.0.1, the it has
+        to be specified as 'v0.0.1'.
+    path : str
+        Path to store the files.
     """
     base_url = "https://github.com/INM-6/h5py_wrapper/archive/"
     r = requests.get(''.join((base_url, version, ".tar.gz")))
@@ -29,7 +37,6 @@ def get_previous_version(version, path):
             f.extractall(path=path)
         os.rename(os.path.join(path, '-'.join(('h5py_wrapper', version))),
                   os.path.join(path, '_'.join(('h5py_wrapper', version.replace('.', '')))))
-        # os.remove(fn)
     except requests.exceptions.HTTPError:
         raise ImportError("Requested release version does not exist.")
 

--- a/h5py_wrapper/lib.py
+++ b/h5py_wrapper/lib.py
@@ -16,7 +16,7 @@ def get_previous_version(version, path):
     archive and extracts its contents to the current directory.
 
     """
-    base_url = "https://github.com/INM-6/h5py_wrapper/archive/v"
+    base_url = "https://github.com/INM-6/h5py_wrapper/archive/"
     r = requests.get(''.join((base_url, version, ".tar.gz")))
     # Convert path to str
     path = str(path)

--- a/h5py_wrapper/lib.py
+++ b/h5py_wrapper/lib.py
@@ -26,7 +26,8 @@ def get_previous_version(version, path):
     """
     base_url = "https://github.com/INM-6/h5py_wrapper/archive/"
     r = requests.get(''.join((base_url, version, ".tar.gz")))
-    # Convert path to str
+    # convert LocalPath object to str (if path to tmp dir is passed by py.test)
+    # to ensure that path can be handled by os.path.join()
     path = str(path)
     try:
         r.raise_for_status()

--- a/h5py_wrapper/lib.py
+++ b/h5py_wrapper/lib.py
@@ -75,12 +75,12 @@ def convert_numpy_types_in_dict(d):
     for key, value in d.items():
         if isinstance(value, dict):
             convert_numpy_types_in_dict(value)
-        elif isinstance(value, (np.int)):
-            d[key] = int(value)
         elif isinstance(value, (np.float)):
             d[key] = float(value)
-        elif isinstance(value, (np.bool_)):
+        elif isinstance(value, (np.bool, np.bool_)):
             d[key] = bool(value)
+        elif isinstance(value, (np.int)):
+            d[key] = int(value)
 
 
 def convert_iterable_to_numpy_array(it):

--- a/h5py_wrapper/lib.py
+++ b/h5py_wrapper/lib.py
@@ -10,7 +10,7 @@ import requests
 import tarfile
 
 
-def get_previous_version(version):
+def get_previous_version(version, path):
     """
     Retrieves the given version of the wrapper from github as a tar
     archive and extracts its contents to the current directory.
@@ -18,17 +18,18 @@ def get_previous_version(version):
     """
     base_url = "https://github.com/INM-6/h5py_wrapper/archive/v"
     r = requests.get(''.join((base_url, version, ".tar.gz")))
+    # Convert path to str
+    path = str(path)
     try:
         r.raise_for_status()
-        fn = ''.join((os.path.join(os.getcwd(), version), '.tar.gz'))
+        fn = ''.join((os.path.join(path, version), '.tar.gz'))
         with open(fn, 'wb') as f:
             f.write(r.content)
         with tarfile.open(fn) as f:
-            f.extract(''.join(('h5py_wrapper-', version, '/wrapper.py')))
-            f.extract(''.join(('h5py_wrapper-', version, '/__init__.py')))
-        os.rename('-'.join(('h5py_wrapper', version)),
-                  '_'.join(('h5py_wrapper', version.replace('.', ''))))
-        os.remove(fn)
+            f.extractall(path=path)
+        os.rename(os.path.join(path, '-'.join(('h5py_wrapper', version))),
+                  os.path.join(path, '_'.join(('h5py_wrapper', version.replace('.', '')))))
+        # os.remove(fn)
     except requests.exceptions.HTTPError:
         raise ImportError("Requested release version does not exist.")
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -319,12 +319,13 @@ def test_file_close_on_exception():
 
 @pytest.mark.skipif(sys.version_info >= (3, 0, 0),
                     reason='Previous release requires Python2')
-def test_conversion_script():
+def test_conversion_script(tmpdir):
     try:
         import h5py_wrapper_001.wrapper as h5w_001
     except ImportError:
-        h5w_lib.get_previous_version('0.0.1')
-        import h5py_wrapper_001.wrapper as h5w_001
+        h5w_lib.get_previous_version('0.0.1', tmpdir)
+        sys.path.append(os.path.join(str(tmpdir), 'h5py_wrapper_001'))
+        import h5py_wrapper.wrapper as h5w_001
 
     res = {key: value for key, value in zip(simpledata_str, simpledata_val)}
     res.update({key: value for key, value in zip(arraydata_str, arraydata_val)})

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -321,27 +321,27 @@ def test_file_close_on_exception():
                     reason='Previous release requires Python2')
 def test_conversion_script(tmpdir):
     try:
-        import h5py_wrapper_001.wrapper as h5w_001
+        import h5py_wrapper_101.wrapper as h5w_101
     except ImportError:
-        h5w_lib.get_previous_version('0.0.1', tmpdir)
-        sys.path.append(os.path.join(str(tmpdir), 'h5py_wrapper_001'))
-        import h5py_wrapper.wrapper as h5w_001
+        h5w_lib.get_previous_version('1.0.1', tmpdir)
+        sys.path.append(os.path.join(str(tmpdir), 'h5py_wrapper_101'))
+        import h5py_wrapper.wrapper as h5w_101
 
     res = {key: value for key, value in zip(simpledata_str, simpledata_val)}
     res.update({key: value for key, value in zip(arraydata_str, arraydata_val)})
-    h5w_001.add_to_h5(fn, res)
-    h5w_001.add_to_h5(fn2, res)
+    h5w_101.add_to_h5(fn, res)
+    h5w_101.add_to_h5(fn2, res)
     with open('conversion_list.txt', 'w') as f:
         f.write(fn)
         f.write('\n')
         f.write(fn2)
     # Specify list on command line
-    os.system('./convert_h5file {} {} --release=0.0.1'.format(fn, fn2))
+    os.system('./convert_h5file {} {} --release=1.0.1'.format(fn, fn2))
     # Read list of files from file and pipe into conversion script
-    os.system('cat conversion_list.txt | ./convert_h5file --release=0.0.1')
+    os.system('cat conversion_list.txt | ./convert_h5file --release=1.0.1')
     os.remove('conversion_list.txt')
     # Find files based on pattern using `find` and pipe into conversion script
-    os.system('find -name "data*.h5" | ./convert_h5file --release=0.0.1')
+    os.system('find -name "data*.h5" | ./convert_h5file --release=1.0.1')
 
     res2 = h5w.load(fn)
     for key, value in res.items():


### PR DESCRIPTION
This PR fixes a bug when converting a file that was created with version 1.0.1:

The boolean value that was stored in the file was erroneously converted to an integer because of the order of type checks in `convert_numpy_types_in_dict`: In Python, a bool is a subclass of integer, i.e. it is also an integer. For instance,

    x = True
    isinstance(x, np.int) --> True

Therefore I had to change the ordering, such that the function first checks if the value is a bool and then if it is an integer. In addition, I had to add a check for `np.bool` because native Python bools are instances of `np.bool` but not of `np.bool_`. 

Note that #71 has to be merged before this PR, because this PR branches off of #71 .