### PR TITLE
Fix readthedocs build error

### DIFF
--- a/doc/api_reference.rst
+++ b/doc/api_reference.rst
@@ -3,7 +3,6 @@ API reference
 =============
 .. toctree::
    :maxdepth: 2
-    index
 	   
 .. currentmodule:: h5py_wrapper
 		   


### PR DESCRIPTION
This PR tries to fix #73 .

The build output on readthedocs.org complained reported a bug in api_refernce.rst which is fixed by this PR. Note that this branch branches off #77 , so #77 has to be merged before this PR.