### PR TITLE
Remove dict_label for next release

### DIFF
--- a/h5py_wrapper/wrapper.py
+++ b/h5py_wrapper/wrapper.py
@@ -36,7 +36,7 @@ if h5py_version_int < 231:
 
 
 def save(filename, d, write_mode='a', overwrite_dataset=False,
-         resize=False, path=None, dict_label='', compression=None):
+         resize=False, path=None, compression=None):
     """
     Save a dictionary to an hdf5 file.
 
@@ -87,15 +87,6 @@ def save(filename, d, write_mode='a', overwrite_dataset=False,
                       "file)".format(filename=filename))
     else:
         try:
-            if dict_label:
-                warnings.warn("Deprecated argument dict_label provided. "
-                              "dict_label will be removed in the next release. "
-                              "Please use path instead.",
-                              DeprecationWarning)
-                if path is not None:
-                    raise ValueError("dict_label and path must not "
-                                     "be defined simultaneously.")
-                path = dict_label                
             if path:
                 base = f.require_group(path)
                 _dict_to_h5(f, d, overwrite_dataset, parent_group=base,

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -392,12 +392,6 @@ def test_conversion_script(tmpdir):
         os.remove(tmp_fn2)
 
 
-def test_raises_error_for_dictlabel_and_path():
-    res = {}
-    with pytest.raises(ValueError):
-        h5w.save(fn, res, dict_label='test', path='test')
-
-
 @pytest.fixture()
 def cleanup():
     yield


### PR DESCRIPTION
This PR removes the `dict_label` argument from the codebase as previsouly announced in the Deprecation warning.